### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>net.imagej</groupId>
-			<artifactId>imagej-legacy</artifactId>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-common</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
@@ -87,11 +87,27 @@
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
-			<artifactId>imagej-common</artifactId>
+			<artifactId>ij</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>net.imagej</groupId>
-			<artifactId>ij</artifactId>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-algorithm</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-ij</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-realtransform</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>bigdataviewer-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
@@ -99,12 +115,26 @@
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
-			<artifactId>bigdataviewer_fiji</artifactId>
+			<artifactId>spim_data</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>SPIM_Registration</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math3</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.itc</groupId>
 			<artifactId>image-transform-converters</artifactId>
 			<version>${image-transform-converters.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-legacy</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
 		<version>29.0.0-beta-3</version>
 	</parent>
+
 	<groupId>de.embl.cba</groupId>
 	<artifactId>transforms-utils</artifactId>
 	<version>0.3.0-SNAPSHOT</version>
-	<url>https://github.com/tischi/transforms-utils</url>
 
 	<name>Transforms Utilities</name>
 	<description>TODO</description>
+	<url>https://github.com/tischi/transforms-utils</url>
 	<inceptionYear>2018</inceptionYear>
 	<organization>
 		<name>EMBL</name>
@@ -24,6 +26,7 @@
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
+
 	<developers>
 		<developer>
 			<id>tischi</id>
@@ -43,12 +46,14 @@
 			<name>TODO</name>
 		</contributor>
 	</contributors>
+
 	<mailingLists>
 		<mailingList>
 			<name>Image.sc Forum</name>
 			<archive>https://forum.image.sc/</archive>
 		</mailingList>
 	</mailingLists>
+
 	<scm>
 		<connection>scm:git:git://github.com/tischi/transforms-utils</connection>
 		<developerConnection>scm:git:git@github.com/tischi/transforms-utils</developerConnection>
@@ -62,6 +67,7 @@
 	<ciManagement>
 		<system>None</system>
 	</ciManagement>
+
 	<properties>
 		<package-name>de.embl.cba.transforms.utils</package-name>
 		<license.licenseName>bsd_2</license.licenseName>
@@ -69,13 +75,7 @@
 
 		<image-transform-converters.version>0.1.2-SNAPSHOT</image-transform-converters.version>
 	</properties>
-	<repositories>
-		<!-- NB: for SciJava dependencies -->
-		<repository>
-			<id>scijava.public</id>
-			<url>https://maven.scijava.org/content/groups/public</url>
-		</repository>
-	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>net.imagej</groupId>
@@ -107,4 +107,12 @@
 			<version>${image-transform-converters.version}</version>
 		</dependency>
 	</dependencies>
+
+	<repositories>
+		<!-- NB: for SciJava dependencies -->
+		<repository>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
+		</repository>
+	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,41 +11,6 @@
 	<version>0.2.01</version>
 	<url>https://github.com/tischi/transforms-utils</url>
 
-	<!--
-	To create an executable jar with maven type:
-	mvn clean package
-	-->
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-						<configuration>
-							<archive>
-								<manifest>
-									<mainClass>
-										de.embl.cba.transforms.utils.LSLFRegistration
-									</mainClass>
-								</manifest>
-							</archive>
-							<outputDirectory>
-								/Users/tischer/Documents/transforms-utils/target
-							</outputDirectory>
-							<descriptorRefs>
-								<descriptorRef>jar-with-dependencies</descriptorRef>
-							</descriptorRefs>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 	<name>Transforms Utilities</name>
 	<description>TODO</description>
 	<inceptionYear>2018</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>de.embl.cba</groupId>
-		<artifactId>pom-embl-cba</artifactId>
-		<version>0.3.10</version>
-		<relativePath>../pom-embl-cba</relativePath>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>29.0.0-beta-3</version>
 	</parent>
+	<groupId>de.embl.cba</groupId>
 	<artifactId>transforms-utils</artifactId>
-	<version>0.2.01</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<url>https://github.com/tischi/transforms-utils</url>
 
 	<name>Transforms Utilities</name>
@@ -45,8 +45,8 @@
 	</contributors>
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/</archive>
 		</mailingList>
 	</mailingLists>
 	<scm>
@@ -66,33 +66,14 @@
 		<package-name>de.embl.cba.transforms.utils</package-name>
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>EMBL</license.copyrightOwners>
-		<imagej.app.directory>/Applications/Fiji.app/</imagej.app.directory>
-		<enforcer.skip>true</enforcer.skip>
+
+		<image-transform-converters.version>0.1.2-SNAPSHOT</image-transform-converters.version>
 	</properties>
-	<distributionManagement>
-		<repository>
-			<id>bintray-tischi-snapshots</id>
-			<name>tischi-snapshots</name>
-			<url>https://api.bintray.com/maven/tischi/snapshots/transforms-utils/;publish=1</url>
-		</repository>
-	</distributionManagement>
 	<repositories>
 		<!-- NB: for SciJava dependencies -->
 		<repository>
-			<id>imagej.public</id>
-			<url>https://maven.imagej.net/content/groups/public</url>
-		</repository>
-		<repository>
-			<id>bintray-tischi-snapshots</id>
-			<url>https://dl.bintray.com/tischi/snapshots</url>
-		</repository>
-		<repository>
-			<id>clij</id>
-			<url>http://dl.bintray.com/haesleinhuepf/clij</url>
-		</repository>
-		<repository>
-			<id>bintray-image-transform-converters-image-transform-converters</id>
-			<url>https://dl.bintray.com/image-transform-converters/image-transform-converters</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
 	<dependencies>
@@ -123,6 +104,7 @@
 		<dependency>
 			<groupId>org.itc</groupId>
 			<artifactId>image-transform-converters</artifactId>
+			<version>${image-transform-converters.version}</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
@tischi if you're ok with these changes, I can follow up with a pull request adding Travis CI.

The changes here were required to make the command line build (`mvn clean install`) pass on my system. While at it, I fixed the dependencies according to the output of `mvn dependency:analyze` (keeping `imagej-legacy` as a `runtime` dependency however, so that the legacy UI is shown when testing interactively).
